### PR TITLE
Update miner public key to match what is stated in the `.env`

### DIFF
--- a/nix/modules/chainweb-mining-client.nix
+++ b/nix/modules/chainweb-mining-client.nix
@@ -4,7 +4,7 @@ let
   cfg = config.services.chainweb-mining-client;
   start-chainweb-mining-client = pkgs.writeShellScript "start-chainweb-mining-client" ''
     ${pkgs.chainweb-mining-client}/bin/chainweb-mining-client \
-    --public-key=f90ef46927f506c70b6a58fd322450a936311dc6ac91f4ec3d8ef949608dbf1f \
+    --public-key=f89ef46927f506c70b6a58fd322450a936311dc6ac91f4ec3d8ef949608dbf1f \
     --node=127.0.0.1:1848 \
     --worker=constant-delay \
     --constant-delay-block-time=5 \

--- a/nix/modules/chainweb-node.nix
+++ b/nix/modules/chainweb-node.nix
@@ -14,7 +14,7 @@ let
     --known-peer-info=YNo8pXthYQ9RQKv1bbpQf2R5LcLYA3ppx2BL2Hf8fIM@bootstrap-node:1789 \
     --log-level=info \
     --enable-mining-coordination \
-    --mining-public-key=f90ef46927f506c70b6a58fd322450a936311dc6ac91f4ec3d8ef949608dbf1f \
+    --mining-public-key=f89ef46927f506c70b6a58fd322450a936311dc6ac91f4ec3d8ef949608dbf1f \
     --header-stream \
     --rosetta \
     --allowReadsInLocal \


### PR DESCRIPTION
Not entirely sure, but the public key in these two files do not match with the `.env` public key for the MINER. I don't know if it was intended or just a typo.