### PR TITLE
Implement a minimal devnet variant with on-demand mining

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,15 +127,19 @@
           services.chainweb-mining-client.enable = true;
           services.http-server.enable = true;
         };
+        on-demand-minimal = {
+          imports = [minimal];
+          services.chainweb-mining-client.worker = "on-demand";
+        };
         default = {
           imports = [minimal];
           services.chainweb-data.enable = true;
-          sites.explorer.enable = 
+          sites.explorer.enable =
             # Enable the explorer only on Linux (which includes all containers)
             # the reason is nginx+lua isn't compiling on darwin as of the current
-            # nixpkgs version we pin. We can remove this once nginx+lua gets fixed 
+            # nixpkgs version we pin. We can remove this once nginx+lua gets fixed
             # on a future nixpkgs update
-            pkgs.lib.mkIf (pkgs.hostPlatform.isLinux) 
+            pkgs.lib.mkIf (pkgs.hostPlatform.isLinux)
               true;
         };
         crashnet = {

--- a/nix/modules/chainweb-mining-client.nix
+++ b/nix/modules/chainweb-mining-client.nix
@@ -2,12 +2,18 @@
 with lib;
 let
   cfg = config.services.chainweb-mining-client;
+  on-demand-port = toString cfg.on-demand-port;
   start-chainweb-mining-client = pkgs.writeShellScript "start-chainweb-mining-client" ''
     ${pkgs.chainweb-mining-client}/bin/chainweb-mining-client \
     --public-key=f89ef46927f506c70b6a58fd322450a936311dc6ac91f4ec3d8ef949608dbf1f \
     --node=127.0.0.1:1848 \
-    --worker=on-demand \
-    --on-demand-port=1790 \
+    --worker=${cfg.worker} \
+    ${optionalString (cfg.on-demand-port != null)
+      "--on-demand-port=${on-demand-port}"
+    }\
+    ${optionalString (cfg.constant-delay-block-time != null)
+      "--constant-delay-block-time=${toString cfg.constant-delay-block-time}"
+    }\
     --thread-count=1 \
     --log-level=info \
     --no-tls
@@ -16,34 +22,57 @@ in
 {
   options.services.chainweb-mining-client = {
     enable = mkEnableOption "Enable the chainweb-mining-client service";
+    worker = mkOption {
+      type = types.enum [ "on-demand" "constant-delay" ];
+      default = "constant-delay";
+      description = "The type of worker to use.";
+    };
+    on-demand-port = mkOption {
+      type = types.nullOr types.int;
+      default = if cfg.worker == "on-demand" then 1790 else null;
+      description = "The port to listen on for on-demand mining requests.";
+      apply = port:
+        trivial.throwIfNot (cfg.worker != "on-demand" || port != null)
+          "The services.chainweb-mining-client.on-demand-port option is mandatory for worker = \"on-demand\""
+          port;
+    };
+    constant-delay-block-time = mkOption {
+      type = types.nullOr types.int;
+      default = if cfg.worker == "constant-delay" then 5 else null;
+      description = "The block time to use for constant-delay mining.";
+    };
   };
-  config = mkIf cfg.enable {
-    packages = [ pkgs.chainweb-mining-client ];
-    processes.chainweb-mining-client = {
-      exec = "${start-chainweb-mining-client}";
-      process-compose = {
-        depends_on.chainweb-node.condition = "process_healthy";
+  config = mkMerge [
+    ( mkIf cfg.enable {
+      packages = [ pkgs.chainweb-mining-client ];
+      processes.chainweb-mining-client = {
+        exec = "${start-chainweb-mining-client}";
+        process-compose = {
+          depends_on.chainweb-node.condition = "process_healthy";
+        };
       };
-    };
-    services.http-server = {
-      upstreams.chainweb-mining-client = "server localhost:1790;";
-      servers.devnet.extraConfig = ''
-        location = /make-blocks {
-          proxy_pass http://chainweb-mining-client/make-blocks;
-          proxy_buffering off;
-        }
-      '';
-    };
-    sites.landing-page.services.chainweb-mining-client = {
-    order = 8;
-    markdown = ''
-      ### On-Demand Mining
-      * [Make blocks](/make-blocks)
-    '';
-  };
-  sites.landing-page.container-api.ports =
-    "- `1790`: On-Demand Mining API";
-  };
- 
-  
+    })
+    ( mkIf (cfg.enable && cfg.worker == "on-demand") {
+      services.http-server = {
+        upstreams.chainweb-mining-client = "server localhost:${on-demand-port};";
+        servers.devnet.extraConfig = ''
+          location = /make-blocks {
+            proxy_pass http://chainweb-mining-client/make-blocks;
+            proxy_buffering off;
+          }
+        '';
+      };
+      sites.landing-page.services.chainweb-mining-client = {
+        order = 8;
+        markdown = ''
+          ### On-Demand Mining
+          This container has a chainweb-mining-client in on-demand mode.
+          You can produce blocks by sending a POST request to the `/make-blocks` endpoint.
+          (see [the relevant section in the chainweb-mining-client README](https://github.com/kadena-io/chainweb-mining-client/tree/master?tab=readme-ov-file#non-pow-mining))
+        '';
+      };
+      sites.landing-page.container-api.ports =
+        "- `${on-demand-port}`: On-Demand Mining API";
+    })
+  ];
 }

--- a/nix/modules/chainweb-mining-client.nix
+++ b/nix/modules/chainweb-mining-client.nix
@@ -6,8 +6,7 @@ let
     ${pkgs.chainweb-mining-client}/bin/chainweb-mining-client \
     --public-key=f89ef46927f506c70b6a58fd322450a936311dc6ac91f4ec3d8ef949608dbf1f \
     --node=127.0.0.1:1848 \
-    --worker=constant-delay \
-    --constant-delay-block-time=5 \
+    --worker=on-demand \
     --thread-count=1 \
     --log-level=info \
     --no-tls
@@ -25,6 +24,25 @@ in
         depends_on.chainweb-node.condition = "process_healthy";
       };
     };
-
+    services.http-server = {
+      upstreams.chainweb-mining-client = "server localhost:1789;";
+      servers.devnet.extraConfig = ''
+        location = /mining-client {
+          proxy_pass http://chainweb-mining-client;
+          proxy_buffering off;
+        }
+      '';
+    };
+    sites.landing-page.services.chainweb-mining-client = {
+    order = 8;
+    markdown = ''
+      ### Mining Client
+      * [Mining client](/mining-client)
+    '';
   };
+  sites.landing-page.container-api.ports =
+    "- `1789`: Mining Client API port";
+  };
+ 
+  
 }

--- a/nix/modules/chainweb-mining-client.nix
+++ b/nix/modules/chainweb-mining-client.nix
@@ -7,6 +7,7 @@ let
     --public-key=f89ef46927f506c70b6a58fd322450a936311dc6ac91f4ec3d8ef949608dbf1f \
     --node=127.0.0.1:1848 \
     --worker=on-demand \
+    --on-demand-port=1790 \
     --thread-count=1 \
     --log-level=info \
     --no-tls
@@ -25,10 +26,10 @@ in
       };
     };
     services.http-server = {
-      upstreams.chainweb-mining-client = "server localhost:1789;";
+      upstreams.chainweb-mining-client = "server localhost:1790;";
       servers.devnet.extraConfig = ''
-        location = /mining-client {
-          proxy_pass http://chainweb-mining-client;
+        location = /make-blocks {
+          proxy_pass http://chainweb-mining-client/make-blocks;
           proxy_buffering off;
         }
       '';
@@ -36,12 +37,12 @@ in
     sites.landing-page.services.chainweb-mining-client = {
     order = 8;
     markdown = ''
-      ### Mining Client
-      * [Mining client](/mining-client)
+      ### On-Demand Mining
+      * [Make blocks](/make-blocks)
     '';
   };
   sites.landing-page.container-api.ports =
-    "- `1789`: Mining Client API port";
+    "- `1790`: On-Demand Mining API";
   };
  
   


### PR DESCRIPTION
This PR came from @salamaashoush

It adds new options to the `services.chainweb-mining-client` module allowing it to be run in the on-demand mining mode. It also exposes an `on-demand-minimal` configuration.