### PR TITLE
Switch to a streamlined graph package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1012,16 +1012,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1711458901,
-        "narHash": "sha256-5v911q70FjZpwxjEHCPMsDd20Gj+LuCYCu70L8nslGQ=",
+        "lastModified": 1711465174,
+        "narHash": "sha256-DLCALddzNmsJ0m5SvHT2y6689ZfvDHwEGnRdQzbBgNE=",
         "owner": "kadena-io",
         "repo": "kadena-nix",
-        "rev": "95450f75daf7f68e054bce127ed816620fb6d706",
+        "rev": "13c270dc0bd362f39d8ad277c546d8329f911278",
         "type": "github"
       },
       "original": {
         "owner": "kadena-io",
-        "ref": "enis/bundle-kadena-graph",
         "repo": "kadena-nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1012,11 +1012,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711375469,
-        "narHash": "sha256-DLCALddzNmsJ0m5SvHT2y6689ZfvDHwEGnRdQzbBgNE=",
+        "lastModified": 1711458901,
+        "narHash": "sha256-5v911q70FjZpwxjEHCPMsDd20Gj+LuCYCu70L8nslGQ=",
         "owner": "kadena-io",
         "repo": "kadena-nix",
-        "rev": "ae6ddcb9a8adf883cf67da3e780cf4a38355b4c1",
+        "rev": "95450f75daf7f68e054bce127ed816620fb6d706",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1012,15 +1012,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1710771252,
-        "narHash": "sha256-cV7YVoSMSLXcvw2MDBDuVU2jvHzdlCAevcdDxFW+6JM=",
+        "lastModified": 1711375469,
+        "narHash": "sha256-DLCALddzNmsJ0m5SvHT2y6689ZfvDHwEGnRdQzbBgNE=",
         "owner": "kadena-io",
         "repo": "kadena-nix",
-        "rev": "712ddcab99f6e0daa19d81dded6f157d3db805fb",
+        "rev": "ae6ddcb9a8adf883cf67da3e780cf4a38355b4c1",
         "type": "github"
       },
       "original": {
         "owner": "kadena-io",
+        "ref": "enis/bundle-kadena-graph",
         "repo": "kadena-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/23.11";
     kadena-nix = {
-      url = "github:kadena-io/kadena-nix";
+      url = "github:kadena-io/kadena-nix/enis/bundle-kadena-graph";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,7 @@
         default = {
           imports = [minimal];
           services.chainweb-data.enable = true;
+          services.graph.enable = true;
           sites.explorer.enable =
             # Enable the explorer only on Linux (which includes all containers)
             # the reason is nginx+lua isn't compiling on darwin as of the current
@@ -174,14 +175,6 @@
           imports = [default];
           services.ttyd.enable = true;
           services.pact-cli.enable = true;
-        };
-        graph = {
-          imports = [container-default];
-          services.graph.enable = true;
-        };
-        crashnet-graph = {
-          imports = [crashnet];
-          services.graph.enable = true;
         };
         # Useful for iterating on nginx configurations
         http-only = {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/23.11";
     kadena-nix = {
-      url = "github:kadena-io/kadena-nix/enis/bundle-kadena-graph";
+      url = "github:kadena-io/kadena-nix";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";

--- a/nix/modules/graph.nix
+++ b/nix/modules/graph.nix
@@ -34,6 +34,7 @@ in {
         environment = [
           "PORT=${port}"
           "PRISMA_LOGGING_ENABLED=true"
+          "NODE_ENV=production"
         ];
         working_dir = graph-folder;
         depends_on.chainweb-data.condition = "process_healthy";


### PR DESCRIPTION
This PR bumps `kadena-nix` to the latest version and brings in a version of the `kadena-graph` Nix package that streamlines its Nix closure. 

With this new `kadena-graph` package as the `graph` service executable, the `graph` variant of the sandbox image shrinks by ~300MB and aside from the `nodejs` dependency (which will be shared with new services we'll add from the `kadena.js` repo) the `graph` service only increases the uncompressed container size by ~20MB, which is small enough that it we can now include `graph` in the default sandbox variant (and also other variants like `crashnet`, so no need for a `crashnet-graph`).

So this PR also moves the `graph` service to the default images and drops all the `*graph` variants.