### PR TITLE
Run health check on the node faster

### DIFF
--- a/node.yaml
+++ b/node.yaml
@@ -52,13 +52,12 @@ services:
         order: stop-first
 
     healthcheck:
-      test: 
+      test:
       - 'CMD'
       - '/bin/bash'
       - '-c'
       - 'exec 3<>/dev/tcp/localhost/1848; printf "GET /health-check HTTP/1.1\r\nhost: http://localhost:1848\r\nConnection: close\r\n\r\n" >&3; grep -q "200 OK" <&3 || exit 1'
-      interval: 30s
+      interval: 1s
       timeout: 30s
-      retries: 5
-      start_period: 2m
-
+      retries: 100
+      start_period: 30s


### PR DESCRIPTION
This makes devnet start significantly faster, as the api proxy is waiting for the node to be healthy.
Change-Id: Id000000000e3c4b8b490b9e9b45c875ce3e75bdd